### PR TITLE
Support time series data represented in epoch time

### DIFF
--- a/src/objects/axis/methods/_parseDate.js
+++ b/src/objects/axis/methods/_parseDate.js
@@ -4,7 +4,10 @@
         this._parseDate = function (inDate) {
             // A javascript date object
             var outDate;
-            if (this.dateParseFormat === null || this.dateParseFormat === undefined) {
+            if (!isNaN(inDate)) {
+                // If inDate is a number, assume it's epoch time
+                outDate = new Date(inDate);
+            } else if (this.dateParseFormat === null || this.dateParseFormat === undefined) {
                 // If nothing has been explicity defined you are in the hands of the browser gods
                 // may they smile upon you...
                 outDate = Date.parse(inDate);


### PR DESCRIPTION
Since it's a bit inefficient if your data is already in milliseconds-since-epoch, to convert it to a string only to have it be parsed out. This is a simple solution that will accept an epoch value, and skip the parsing, and create a `Date` object direct.

Ref #16 
