### PR TITLE
allow multiple different series

### DIFF
--- a/dist/dimple.v1.1.4.js
+++ b/dist/dimple.v1.1.4.js
@@ -544,7 +544,7 @@ var dimple = {
                         yCat = "",
                         ySortArray = [],
                         rules = [],
-                        sortedData = this.data,
+                        sortedData =series.data || this.data,
                         groupRules = [];
 
                     if (this.storyboard !== null && this.storyboard !== undefined && this.storyboard.categoryFields.length > 0) {


### PR DESCRIPTION
Allowing multiple different series to attach to the same series upon construct the data.

When send the data directly into the API, you can use series.data as customized array to allow multiple different graphic exist in the same series.  
