### PR TITLE
Handle opacity change on line chart redraw

### DIFF
--- a/src/methods/_drawMarkers.js
+++ b/src/methods/_drawMarkers.js
@@ -63,6 +63,7 @@
             .attr("cx", function (d) { return dimple._helpers.cx(d, chart, series); })
             .attr("cy", function (d) { return dimple._helpers.cy(d, chart, series); })
             .attr("r", 2 + series.lineWeight)
+            .attr("opacity", (series.lineMarkers || lineDataRow.data.length < 2 ? lineDataRow.color.opacity : 0))
             .call(function () {
                 if (!chart.noFormats) {
                     this.attr("fill", "white")


### PR DESCRIPTION
The check in dimple._drawMarkers to set the opacity of markers (based on the number of data points on the chart) is only computed on the enter join. If the number of data points changes after that and the chart is redrawn, the original opacity is kept even if it changes from only one data point (where markers should always be visible) to many or from many to one. This change runs the same computation on the update join of the markers.

jsbin : http://jsbin.com/ticede/1/edit?js,output
