### PR TITLE
Allow increasing the space between legend entries 

### DIFF
--- a/src/objects/legend/methods/_draw.js
+++ b/src/objects/legend/methods/_draw.js
@@ -68,8 +68,8 @@
 
             // Expand the bounds of the largest shape slightly.  This will be the size allocated to
             // all elements
-            maxHeight = (maxHeight < keyHeight ? keyHeight : maxHeight) + 2;
-            maxWidth += keyWidth + 20;
+            maxHeight = (maxHeight < keyHeight ? keyHeight : maxHeight) + self._getVerticalPadding();
+            maxWidth += keyWidth + self._getHorizontalPadding();
 
             // Iterate the shapes and position them based on the alignment and size of the legend
             theseShapes

--- a/src/objects/legend/methods/_draw.js
+++ b/src/objects/legend/methods/_draw.js
@@ -12,6 +12,7 @@
                 runningY = 0,
                 keyWidth = 15,
                 keyHeight = 9,
+                distanceBetweenKeyAndText = 5,
                 self = this,
                 theseShapes;
 
@@ -82,7 +83,7 @@
                         d3.select(this).remove();
                     } else {
                         d3.select(this).select("text")
-                            .attr("x", (self.horizontalAlign === "left" ? self._xPixels() + keyWidth + 5 + runningX : self._xPixels() + (self._widthPixels() - runningX - maxWidth) + keyWidth + 5))
+                            .attr("x", (self.horizontalAlign === "left" ? self._xPixels() + keyWidth + distanceBetweenKeyAndText + runningX : self._xPixels() + (self._widthPixels() - runningX - maxWidth) + keyWidth + distanceBetweenKeyAndText))
                             .attr("y", function () {
                                 // This was previously done with dominant-baseline but this is used
                                 // instead due to browser inconsistency.

--- a/src/objects/legend/methods/_getHorizontalPadding.js
+++ b/src/objects/legend/methods/_getHorizontalPadding.js
@@ -1,0 +1,12 @@
+        // Copyright: 2015 PMSI-AlignAlytics
+        // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
+        // Source: /src/objects/legend/methods/_getHorizontalPadding.js
+        this._getHorizontalPadding = function () {
+            var horizontalPadding;
+            if (isNaN(this.horizontalPadding)) {
+                horizontalPadding = 20;
+            } else {
+                horizontalPadding = this.horizontalPadding;
+            }
+            return horizontalPadding;
+        };

--- a/src/objects/legend/methods/_getVerticalPadding.js
+++ b/src/objects/legend/methods/_getVerticalPadding.js
@@ -1,0 +1,12 @@
+        // Copyright: 2015 PMSI-AlignAlytics
+        // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
+        // Source: /src/objects/legend/methods/_getVerticalPadding.js
+        this._getVerticalPadding = function () {
+            var verticalPadding;
+            if (isNaN(this.verticalPadding)) {
+                verticalPadding = 2;
+            } else {
+                verticalPadding = this.verticalPadding;
+            }
+            return verticalPadding;
+        };


### PR DESCRIPTION
I also thought of allowing the configuration of the distance between the key and the text, but I wasn't sure if dimple should be configurable to such level of granularity.

I think the attributes' names (`verticalPadding` and `horizontalPadding`) could be more explicit, but I couldn't come up with better names.

I'll be happy to edit the documentation to mention these attributes if this patch gets merged.