### PR TITLE
Allow disabling auto-rotation of axis labels

### DIFF
--- a/src/objects/axis/begin.js
+++ b/src/objects/axis/begin.js
@@ -2,7 +2,7 @@
     // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
     // Source: /src/objects/axis/begin.js
     // Help: http://github.com/PMSI-AlignAlytics/dimple/wiki/dimple.axis
-    dimple.axis = function (chart, position, categoryFields, measure, timeField) {
+    dimple.axis = function (chart, position, categoryFields, measure, timeField, autoRotateLabel) {
 
         // Help: http://github.com/PMSI-AlignAlytics/dimple/wiki/dimple.axis#wiki-chart
         this.chart = chart;
@@ -56,6 +56,8 @@
         this.fontSize = "10px";
         // Help: http://github.com/PMSI-AlignAlytics/dimple/wiki/dimple.axis#wiki-fontFamily
         this.fontFamily = "sans-serif";
+        // Help: http://github.com/PMSI-AlignAlytics/dimple/wiki/dimple.axis#wiki-autoRotateLabel
+        this.autoRotateLabel = (autoRotateLabel === null || autoRotateLabel === undefined ? true : autoRotateLabel);
 
         // If this is a composite axis, store links to all slaves
         this._slaves = [];

--- a/src/objects/chart/methods/draw.js
+++ b/src/objects/chart/methods/draw.js
@@ -283,7 +283,7 @@
                         });
                 }
                 // Rotate labels, this can only be done once the formats are set
-                if (axis.measure === null || axis.measure === undefined) {
+                if (axis.autoRotateLabel && (axis.measure === null || axis.measure === undefined)) {
                     if (axis === firstX) {
                         // If the gaps are narrower than the widest label display all labels horizontally
                         widest = 0;
@@ -332,6 +332,11 @@
                                 .attr("transform", "");
                         }
                     }
+                } else {
+                    rotated = false;
+                    axis.shapes.selectAll("text")
+                        .style("text-anchor", "middle")
+                        .attr("transform", "");
                 }
                 if (axis.titleShape !== null && axis.titleShape !== undefined) {
                     axis.titleShape.remove();


### PR DESCRIPTION
Adds a property, autoRotateLabel, and parameter to the axis constructor, which allows disabling the auto-rotation of axis labels.

This is done to allow manual rotation to arbitrary angles without having to worry about if the label may be auto rotated by dimple.

Default behavior is to maintain backwards compatibility and continue rotating.

Will look to contribute the manual rotation support if possible.

Can update wiki to make help link valid.