### PR TITLE
Fix issue #167 ("Examples are broken")

### DIFF
--- a/examples/templates/advanced_animated_multiple_pie_bubbles.html
+++ b/examples/templates/advanced_animated_multiple_pie_bubbles.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -39,3 +42,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_bar_labels.html
+++ b/examples/templates/advanced_bar_labels.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -44,3 +47,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_bullet.html
+++ b/examples/templates/advanced_bullet.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -124,3 +127,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_change_bubbles.html
+++ b/examples/templates/advanced_change_bubbles.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -94,3 +97,4 @@
         });
     </script>
 </div>
+</html>

--- a/examples/templates/advanced_custom_styling.html
+++ b/examples/templates/advanced_custom_styling.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -117,3 +120,4 @@
 
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_dynamic_line_color.html
+++ b/examples/templates/advanced_dynamic_line_color.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -31,3 +34,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_grouped_mekko.html
+++ b/examples/templates/advanced_grouped_mekko.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -45,3 +48,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_interactive_legends.html
+++ b/examples/templates/advanced_interactive_legends.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -72,3 +75,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_lollipop_with_hover.html
+++ b/examples/templates/advanced_lollipop_with_hover.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -127,3 +130,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_matrix.html
+++ b/examples/templates/advanced_matrix.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -92,3 +95,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_pong.html
+++ b/examples/templates/advanced_pong.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -68,3 +71,4 @@
         
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_price_range_lollipop.html
+++ b/examples/templates/advanced_price_range_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -42,3 +45,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_responsive_sizing.html
+++ b/examples/templates/advanced_responsive_sizing.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer" style="height: 100%">
     {scriptDependencies}
     <script type="text/javascript">
@@ -78,3 +81,4 @@
 
     </script>
 </div>
+</html>

--- a/examples/templates/advanced_storyboard_control.html
+++ b/examples/templates/advanced_storyboard_control.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -129,3 +132,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_time_axis.html
+++ b/examples/templates/advanced_time_axis.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -101,3 +104,4 @@
 
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_trellis_bar.html
+++ b/examples/templates/advanced_trellis_bar.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -89,3 +92,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/advanced_waterfall.html
+++ b/examples/templates/advanced_waterfall.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -125,3 +128,4 @@
     
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_horizontal.html
+++ b/examples/templates/area_steps_horizontal.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_horizontal_grouped.html
+++ b/examples/templates/area_steps_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_horizontal_grouped_100pct.html
+++ b/examples/templates/area_steps_horizontal_grouped_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -18,3 +21,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_horizontal_grouped_stacked.html
+++ b/examples/templates/area_steps_horizontal_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -18,3 +21,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_horizontal_stacked.html
+++ b/examples/templates/area_steps_horizontal_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_horizontal_stacked_100pct.html
+++ b/examples/templates/area_steps_horizontal_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_vertical.html
+++ b/examples/templates/area_steps_vertical.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_vertical_grouped.html
+++ b/examples/templates/area_steps_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_vertical_grouped_100pct.html
+++ b/examples/templates/area_steps_vertical_grouped_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -18,3 +21,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_vertical_grouped_stacked.html
+++ b/examples/templates/area_steps_vertical_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -18,3 +21,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_vertical_stacked.html
+++ b/examples/templates/area_steps_vertical_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/area_steps_vertical_stacked_100pct.html
+++ b/examples/templates/area_steps_vertical_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_curvy.html
+++ b/examples/templates/areas_curvy.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_dual_measure.html
+++ b/examples/templates/areas_dual_measure.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_horizontal.html
+++ b/examples/templates/areas_horizontal.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_horizontal_grouped.html
+++ b/examples/templates/areas_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_horizontal_grouped_100pct.html
+++ b/examples/templates/areas_horizontal_grouped_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_horizontal_grouped_stacked.html
+++ b/examples/templates/areas_horizontal_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_horizontal_stacked.html
+++ b/examples/templates/areas_horizontal_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_horizontal_stacked_100pct.html
+++ b/examples/templates/areas_horizontal_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_vertical.html
+++ b/examples/templates/areas_vertical.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_vertical_grouped.html
+++ b/examples/templates/areas_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_vertical_grouped_100pct.html
+++ b/examples/templates/areas_vertical_grouped_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_vertical_grouped_stacked.html
+++ b/examples/templates/areas_vertical_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_vertical_stacked.html
+++ b/examples/templates/areas_vertical_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/areas_vertical_stacked_100pct.html
+++ b/examples/templates/areas_vertical_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_dual_measure_floating.html
+++ b/examples/templates/bars_dual_measure_floating.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal.html
+++ b/examples/templates/bars_horizontal.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal_floating.html
+++ b/examples/templates/bars_horizontal_floating.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal_grouped.html
+++ b/examples/templates/bars_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal_grouped_stacked.html
+++ b/examples/templates/bars_horizontal_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal_grouped_stacked_100pct.html
+++ b/examples/templates/bars_horizontal_grouped_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal_mekko.html
+++ b/examples/templates/bars_horizontal_mekko.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal_stacked.html
+++ b/examples/templates/bars_horizontal_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_horizontal_stacked_100pct.html
+++ b/examples/templates/bars_horizontal_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_matrix.html
+++ b/examples/templates/bars_matrix.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical.html
+++ b/examples/templates/bars_vertical.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical_floating.html
+++ b/examples/templates/bars_vertical_floating.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical_grouped.html
+++ b/examples/templates/bars_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical_grouped_stacked.html
+++ b/examples/templates/bars_vertical_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical_grouped_stacked_100pct.html
+++ b/examples/templates/bars_vertical_grouped_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical_mekko.html
+++ b/examples/templates/bars_vertical_mekko.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical_stacked.html
+++ b/examples/templates/bars_vertical_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bars_vertical_stacked_100pct.html
+++ b/examples/templates/bars_vertical_stacked_100pct.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bubbles_horizontal_grouped.html
+++ b/examples/templates/bubbles_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bubbles_horizontal_lollipop.html
+++ b/examples/templates/bubbles_horizontal_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -18,3 +21,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/bubbles_matrix.html
+++ b/examples/templates/bubbles_matrix.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bubbles_standard.html
+++ b/examples/templates/bubbles_standard.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/bubbles_vertical_grouped.html
+++ b/examples/templates/bubbles_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/bubbles_vertical_lollipop.html
+++ b/examples/templates/bubbles_vertical_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -18,3 +21,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_curvy.html
+++ b/examples/templates/lines_curvy.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_dual_measure.html
+++ b/examples/templates/lines_dual_measure.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_horizontal.html
+++ b/examples/templates/lines_horizontal.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_horizontal_grouped.html
+++ b/examples/templates/lines_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_horizontal_grouped_stacked.html
+++ b/examples/templates/lines_horizontal_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_horizontal_stacked.html
+++ b/examples/templates/lines_horizontal_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_vertical.html
+++ b/examples/templates/lines_vertical.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_vertical_grouped.html
+++ b/examples/templates/lines_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_vertical_grouped_stacked.html
+++ b/examples/templates/lines_vertical_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/lines_vertical_stacked.html
+++ b/examples/templates/lines_vertical_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_bubble.html
+++ b/examples/templates/pie_bubble.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_horizontal_grouped.html
+++ b/examples/templates/pie_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_horizontal_lollipop.html
+++ b/examples/templates/pie_horizontal_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -19,3 +22,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_matrix.html
+++ b/examples/templates/pie_matrix.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_scatter.html
+++ b/examples/templates/pie_scatter.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_standard.html
+++ b/examples/templates/pie_standard.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -12,3 +15,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_vertical_grouped.html
+++ b/examples/templates/pie_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/pie_vertical_lollipop.html
+++ b/examples/templates/pie_vertical_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -19,3 +22,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_bubble.html
+++ b/examples/templates/ring_bubble.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_horizontal_grouped.html
+++ b/examples/templates/ring_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_horizontal_lollipop.html
+++ b/examples/templates/ring_horizontal_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -20,3 +23,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_matrix.html
+++ b/examples/templates/ring_matrix.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_multiple.html
+++ b/examples/templates/ring_multiple.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_scatter.html
+++ b/examples/templates/ring_scatter.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_standard.html
+++ b/examples/templates/ring_standard.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_vertical_grouped.html
+++ b/examples/templates/ring_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/ring_vertical_lollipop.html
+++ b/examples/templates/ring_vertical_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -20,3 +23,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/scatter_horizontal_grouped.html
+++ b/examples/templates/scatter_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/scatter_horizontal_lollipop.html
+++ b/examples/templates/scatter_horizontal_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/scatter_matrix.html
+++ b/examples/templates/scatter_matrix.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/scatter_standard.html
+++ b/examples/templates/scatter_standard.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/scatter_vertical_grouped.html
+++ b/examples/templates/scatter_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -13,3 +16,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/scatter_vertical_lollipop.html
+++ b/examples/templates/scatter_vertical_lollipop.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -14,3 +17,4 @@
       });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_horizontal.html
+++ b/examples/templates/steps_horizontal.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_horizontal_grouped.html
+++ b/examples/templates/steps_horizontal_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_horizontal_grouped_stacked.html
+++ b/examples/templates/steps_horizontal_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_horizontal_stacked.html
+++ b/examples/templates/steps_horizontal_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_vertical.html
+++ b/examples/templates/steps_vertical.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -15,3 +18,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_vertical_grouped.html
+++ b/examples/templates/steps_vertical_grouped.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_vertical_grouped_stacked.html
+++ b/examples/templates/steps_vertical_grouped_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -17,3 +20,4 @@
     });
   </script>
 </div>
+</html>

--- a/examples/templates/steps_vertical_stacked.html
+++ b/examples/templates/steps_vertical_stacked.html
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
 <div id="chartContainer">
   {scriptDependencies}
   <script type="text/javascript">
@@ -16,3 +19,4 @@
     });
   </script>
 </div>
+</html>


### PR DESCRIPTION
Explicitly set document encoding to utf-8.  Also add `<!DOCTYPE html>`
tag and `<html>...</html>` for good measure.

Only `examples/templates/*.html` files have been modified.