### PR TITLE
Update dimple.v2.1.6.js

### DIFF
--- a/dist/dimple.v2.1.6.js
+++ b/dist/dimple.v2.1.6.js
@@ -4802,7 +4802,7 @@
     // Source: /src/methods/_parentHeight.js
     dimple._parentHeight = function (parent) {
         // This one seems to work in Chrome - good old Chrome!
-        var returnValue = parent.offsetHeight;
+        var returnValue = parent.getBoundingClientRect().height;
         // This does it for IE
         if (returnValue <= 0 || returnValue === null || returnValue === undefined) {
             returnValue = parent.clientHeight;
@@ -4829,7 +4829,7 @@
     // Source: /src/methods/_parentWidth.js
     dimple._parentWidth = function (parent) {
         // This one seems to work in Chrome - good old Chrome!
-        var returnValue = parent.offsetWidth;
+        var returnValue = parent.getBoundingClientRect().width;
         // This does it for IE
         if (!returnValue || returnValue < 0) {
             returnValue = parent.clientWidth;


### PR DESCRIPTION
offsetHeight and offsetWidth are being deprecated in April 2016.  Modified the calls to reflect the new standard.