### PR TITLE
Update _parentWidth.js

### DIFF
--- a/src/methods/_parentWidth.js
+++ b/src/methods/_parentWidth.js
@@ -2,25 +2,11 @@
     // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
     // Source: /src/methods/_parentWidth.js
     dimple._parentWidth = function (parent) {
-        // This one seems to work in Chrome - good old Chrome!
-        var returnValue = parent.offsetWidth;
-        // This does it for IE
+         // Let's be explicit about what we are trying to get here
+        var returnValue = parent.getBoundingClientRect().width;
+        // If it returns nothing then go with "clientWidth"
         if (!returnValue || returnValue < 0) {
             returnValue = parent.clientWidth;
-        }
-        // FireFox is the hard one this time.  See this bug report:
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=649285//
-        // It's dealt with by trying to recurse up the dom until we find something
-        // we can get a size for.  Usually the parent of the SVG.  It's a bit costly
-        // but I don't know of any other way.
-        if (!returnValue || returnValue < 0) {
-            if (!parent.parentNode) {
-                // Give up - Recursion Exit Point
-                returnValue = 0;
-            } else {
-                // Get the size from the parent recursively
-                returnValue = dimple._parentWidth(parent.parentNode);
-            }
         }
         return returnValue;
     };


### PR DESCRIPTION
The firefox issue (https://bugzilla.mozilla.org/show_bug.cgi?id=649285) was closed as invalid.
Chrome is also deprecating offsetWidth and offsetHeight in April 2016.
parent.getBoundingClientRect().width is a more explicit call to get the outer object width