### PR TITLE
chart now capable of displaying multiple tooltips

### DIFF
--- a/src/methods/_removeTooltip.js
+++ b/src/methods/_removeTooltip.js
@@ -3,8 +3,8 @@
     // Source: /src/methods/_removeTooltip.js
     /*jslint unparam: true */
     dimple._removeTooltip = function (e, shape, chart, series) {
-        if (chart._tooltipGroup) {
-            chart._tooltipGroup.remove();
+        if (chart._tooltipGroups[e.key]) {
+            chart._tooltipGroups[e.key].remove();
         }
     };
     /*jslint unparam: false */

--- a/src/methods/_showBarTooltip.js
+++ b/src/methods/_showBarTooltip.js
@@ -52,10 +52,14 @@
                 return position.matrixTransform(matrix);
             };
 
-        if (chart._tooltipGroup !== null && chart._tooltipGroup !== undefined) {
-            chart._tooltipGroup.remove();
+        if (chart._tooltipGroups === null || chart._tooltipGroups === undefined) {
+            chart._tooltipGroups = {};
         }
-        chart._tooltipGroup = chart.svg.append("g");
+        if (chart._tooltipGroups[e.key] !== null && chart._tooltipGroups[e.key] !== undefined) {
+            chart._tooltipGroups[e.key].remove();
+        }
+
+        chart._tooltipGroups[e.key] = chart.svg.append('g');
 
         if (!series.p) {
 
@@ -63,7 +67,7 @@
 
             // Add a drop line to the x axis
             if (!series.x._hasCategories() && dropDest.y !== null) {
-                chart._tooltipGroup.append("line")
+                chart._tooltipGroups[e.key].append("line")
                     .attr("class", "dimple-tooltip-dropline " + chart.customClassList.tooltipDropLine)
                     .attr("x1", (x < series.x._origin ? x + offset : x + width - offset))
                     .attr("y1", (y < dropDest.y ? y + height : y))
@@ -93,7 +97,7 @@
 
             // Add a drop line to the y axis
             if (!series.y._hasCategories() && dropDest.x !== null) {
-                chart._tooltipGroup.append("line")
+                chart._tooltipGroups[e.key].append("line")
                     .attr("class", "dimple-tooltip-dropline " + chart.customClassList.tooltipDropLine)
                     .attr("x1", (x < dropDest.x ? x + width : x))
                     .attr("y1", (y < series.y._origin ? y + offset : y + height - offset))
@@ -122,7 +126,7 @@
         }
 
         // Add a group for text
-        t = chart._tooltipGroup.append("g");
+        t = chart._tooltipGroups[e.key].append("g");
         // Create a box for the popup in the text group
         box = t.append("rect")
             .attr("class", "dimple-tooltip " + chart.customClassList.tooltipBox);

--- a/src/methods/_showPointTooltip.js
+++ b/src/methods/_showPointTooltip.js
@@ -40,13 +40,18 @@
             translateX,
             translateY;
 
-        if (chart._tooltipGroup !== null && chart._tooltipGroup !== undefined) {
-            chart._tooltipGroup.remove();
+
+        if (chart._tooltipGroups !== null && chart._tooltipGroups !== undefined) {
+            chart._tooltipGroups = {};
         }
-        chart._tooltipGroup = chart.svg.append("g");
+        if (chart._tooltipGroups[e.key] !== null && chart._tooltipGroups[e.key] !== undefined) {
+            chart._tooltipGroups[e.key].remove();
+        }
+
+        chart._tooltipGroups[e.key] = chart.svg.append('g');
 
         // Add a ring around the data point
-        chart._tooltipGroup.append("circle")
+        chart._tooltipGroup[e.key].append("circle")
             .attr("class", "dimple-line-marker-circle " + chart.customClassList.lineMarkerCircle)
             .attr("cx", cx)
             .attr("cy", cy)
@@ -72,7 +77,7 @@
 
         // Add a drop line to the x axis
         if (dropDest.y !== null) {
-            chart._tooltipGroup.append("line")
+            chart._tooltipGroup[e.key].append("line")
                 .attr("class", "dimple-tooltip-dropline " + chart.customClassList.tooltipDropLine)
                 .attr("x1", cx)
                 .attr("y1", (cy < dropDest.y ? cy + r + series.lineWeight + 2 : cy - r - series.lineWeight - 2))
@@ -99,7 +104,7 @@
 
         // Add a drop line to the y axis
         if (dropDest.x !== null) {
-            chart._tooltipGroup.append("line")
+            chart._tooltipGroup[e.key].append("line")
                 .attr("class", "dimple-tooltip-dropline " + chart.customClassList.tooltipDropLine)
                 .attr("x1", (cx < dropDest.x ? cx + r + series.lineWeight + 2 : cx - r - series.lineWeight - 2))
                 .attr("y1", cy)
@@ -125,7 +130,7 @@
         }
 
         // Add a group for text
-        t = chart._tooltipGroup.append("g");
+        t = chart._tooltipGroup[e.key].append("g");
         // Create a box for the popup in the text group
         box = t.append("rect")
             .attr("class", "dimple-tooltip " + chart.customClassList.tooltipBox);

--- a/src/methods/_showPointTooltip.js
+++ b/src/methods/_showPointTooltip.js
@@ -41,7 +41,7 @@
             translateY;
 
 
-        if (chart._tooltipGroups !== null && chart._tooltipGroups !== undefined) {
+        if (chart._tooltipGroups === null || chart._tooltipGroups === undefined) {
             chart._tooltipGroups = {};
         }
         if (chart._tooltipGroups[e.key] !== null && chart._tooltipGroups[e.key] !== undefined) {
@@ -51,7 +51,7 @@
         chart._tooltipGroups[e.key] = chart.svg.append('g');
 
         // Add a ring around the data point
-        chart._tooltipGroup[e.key].append("circle")
+        chart._tooltipGroups[e.key].append("circle")
             .attr("class", "dimple-line-marker-circle " + chart.customClassList.lineMarkerCircle)
             .attr("cx", cx)
             .attr("cy", cy)
@@ -77,7 +77,7 @@
 
         // Add a drop line to the x axis
         if (dropDest.y !== null) {
-            chart._tooltipGroup[e.key].append("line")
+            chart._tooltipGroups[e.key].append("line")
                 .attr("class", "dimple-tooltip-dropline " + chart.customClassList.tooltipDropLine)
                 .attr("x1", cx)
                 .attr("y1", (cy < dropDest.y ? cy + r + series.lineWeight + 2 : cy - r - series.lineWeight - 2))
@@ -104,7 +104,7 @@
 
         // Add a drop line to the y axis
         if (dropDest.x !== null) {
-            chart._tooltipGroup[e.key].append("line")
+            chart._tooltipGroups[e.key].append("line")
                 .attr("class", "dimple-tooltip-dropline " + chart.customClassList.tooltipDropLine)
                 .attr("x1", (cx < dropDest.x ? cx + r + series.lineWeight + 2 : cx - r - series.lineWeight - 2))
                 .attr("y1", cy)
@@ -130,7 +130,7 @@
         }
 
         // Add a group for text
-        t = chart._tooltipGroup[e.key].append("g");
+        t = chart._tooltipGroups[e.key].append("g");
         // Create a box for the popup in the text group
         box = t.append("rect")
             .attr("class", "dimple-tooltip " + chart.customClassList.tooltipBox);


### PR DESCRIPTION
I need to display multiple tooltips on a parallel-coordinates chart that I'm working on (http://github.com/jmcmichael/linked-scatterplots), and noticed that dimple._showBar/PointTooltip stores a single reference to a tooltip SVG group, thus limiting charts to a single tooltip.

I've updated the _showBarTooltip, _showPointTooltip, and _removeTooltip functions to store references to tooltip groups in an object indexed by d3's event key field. Multiple tooltips now work (they do my chart, anyway - I should probably a simplified version as an example), and I checked several examples to ensure that the existing tooltip behavior remains preserved.