### PR TITLE
Support tickFormat callback

### DIFF
--- a/dist/dimple.latest.js
+++ b/dist/dimple.latest.js
@@ -181,6 +181,9 @@
                 chunks,
                 suffix,
                 dp;
+            if (typeof this.tickFormat == 'function') {
+                return this.tickFormat;
+            }
             if (this.tickFormat !== null && this.tickFormat !== undefined) {
                 if (this._hasTimeField()) {
                     returnFormat = d3.time.format(this.tickFormat);

--- a/dist/dimple.v2.2.0.js
+++ b/dist/dimple.v2.2.0.js
@@ -181,6 +181,9 @@
                 chunks,
                 suffix,
                 dp;
+            if (typeof this.tickFormat == 'function') {
+                return this.tickFormat;
+            }
             if (this.tickFormat !== null && this.tickFormat !== undefined) {
                 if (this._hasTimeField()) {
                     returnFormat = d3.time.format(this.tickFormat);

--- a/src/objects/axis/methods/_getFormat.js
+++ b/src/objects/axis/methods/_getFormat.js
@@ -9,6 +9,9 @@
                 chunks,
                 suffix,
                 dp;
+            if (typeof this.tickFormat == 'function') {
+                return this.tickFormat;
+            }
             if (this.tickFormat !== null && this.tickFormat !== undefined) {
                 if (this._hasTimeField()) {
                     returnFormat = d3.time.format(this.tickFormat);


### PR DESCRIPTION
Dimple lacks a very important function - custom formatters via callback
This patch adds the support for it