### PR TITLE
Correctly initialize min/max of boundary search

### DIFF
--- a/src/objects/axis/begin.js
+++ b/src/objects/axis/begin.js
@@ -64,8 +64,8 @@
         // The scale determined by the update method
         this._scale = null;
         // The minimum and maximum axis values
-        this._min = 0;
-        this._max = 0;
+        this._min = Infinity;
+        this._max = -Infinity;
         // Chart origin before and after an update.  This helps
         // with transitions
         this._previousOrigin = null;

--- a/src/objects/chart/methods/draw.js
+++ b/src/objects/chart/methods/draw.js
@@ -31,8 +31,8 @@
             // Iterate the axes and calculate bounds, this is done within the chart because an
             // axis' bounds are determined by other axes and the way that series tie them together
             this.axes.forEach(function (axis) {
-                axis._min = 0;
-                axis._max = 0;
+                axis._min = Infinity;
+                axis._max = -Infinity;
                 linkedDimensions = [];
                 // Check that the axis has a measure
                 if (axis._hasMeasure()) {

--- a/src/objects/series/methods/_axisBounds.js
+++ b/src/objects/series/methods/_axisBounds.js
@@ -2,7 +2,7 @@
         // License: "https://github.com/PMSI-AlignAlytics/dimple/blob/master/MIT-LICENSE.txt"
         // Source: /src/objects/series/methods/_axisBounds.js
         this._axisBounds = function (position) {
-            var bounds = { min: 0, max: 0 },
+            var bounds = { min: Infinity, max: -Infinity },
                 // The primary axis for this comparison
                 primaryAxis = null,
                 // The secondary axis for this comparison
@@ -78,7 +78,11 @@
                     }
                     // Get the index of the field
                     if (categoryTotals[index] === undefined) {
-                        categoryTotals[index] = { min: 0, max: 0 };
+                        if (this.stacked) {
+                            categoryTotals[index] = { min: 0, max: 0 };
+                        } else {
+                            categoryTotals[index] = { min: Infinity, max: -Infinity };
+                        }
                         if (index >= catCount) {
                             catCount = index + 1;
                         }


### PR DESCRIPTION
If the minimum value is greater than 0, or the maximum value is less than 0, then initializing those values with 0 leads to incorrect results.

---

Example:
```html
<html>
  <div id="chartContainer">
  <script src="/lib/d3.v3.4.8.js"></script>
  <script src="/lib/dimple.v2.2.0.min.js"></script>
  <script type="text/javascript">
    var svg = dimple.newSvg("#chartContainer", 590, 400);
    d3.tsv("/data/example_data.tsv", function (data) {
      var c = new dimple.chart(svg, data);
      c.addMeasureAxis("x", "Year").tickFormat = "d";
      c.addMeasureAxis("y", "Count");
      c.addSeries("Year", dimple.plot.line);
      c.draw();
    });
  </script>
</div>
</html>
```
```tsv
Year	Count
2010	100
2011	97
2013	127
2014	106
2015	108
2016	78
```
Without this patch, X and Y axis will start at 0, squashing all the data into a tiny area of an otherwise empty chart.