### PR TITLE
Switching comparison to less than. Updating d3 version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/PMSI-AlignAlytics/dimple.git"
     },
     "dependencies": {
-        "d3": ">=3.5.2"
+        "d3": "<=3.5.17"
     },
     "version": "2.2.0",
     "homepage": "dimplejs.org",


### PR DESCRIPTION
D3 version 3.5.17 is the last 3.X version that is compatible with the current dimple implementation. D3 version 4.0 and forward, D3 has been broken down into smaller modules and is not backward compatible.
Also, notice that I switch the comparison, version 3.5.17 and older are compatible, 4.0 (which is the following release) and further are not.