### PR TITLE
Add mechanism to control application of .nice()

### DIFF
--- a/src/objects/axis/begin.js
+++ b/src/objects/axis/begin.js
@@ -58,6 +58,8 @@
         this.fontFamily = "sans-serif";
         // Help: http://github.com/PMSI-AlignAlytics/dimple/wiki/dimple.axis#wiki-autoRotateLabel
         this.autoRotateLabel = (autoRotateLabel === null || autoRotateLabel === undefined ? true : autoRotateLabel);
+        // whether the tickCount (if specified) should be applied to call to .nice() when building the axis scale
+        this.forceTickCount = false;
 
         // If this is a composite axis, store links to all slaves
         this._slaves = [];

--- a/src/objects/axis/methods/_update.js
+++ b/src/objects/axis/methods/_update.js
@@ -9,6 +9,7 @@
                 remainder,
                 origin,
                 tickCount = this.ticks || 10,
+                niceTickCount = this.forceTickCount && this.ticks ? tickCount : undefined,
                 getOrderedCategories = function (self, axPos, oppPos) {
                     var category = self.categoryFields[0],
                         axisData = self._getAxisData(),
@@ -65,7 +66,7 @@
                         ])
                         .clamp(this.clamp)
                         .base(this.logBase)
-                        .nice();
+                        .nice(niceTickCount);
                 } else if (this.measure === null || this.measure === undefined) {
                     distinctCats = getOrderedCategories(this, "x", "y");
                     // If there are any slaves process accordingly
@@ -82,7 +83,7 @@
                         .range([this.chart._xPixels(), this.chart._xPixels() + this.chart._widthPixels()])
                         .domain([this._min, this._max])
                         .clamp(this.clamp)
-                        .nice();
+                        .nice(niceTickCount);
                 }
                 // If it's visible, orient it at the top or bottom if it's first or second respectively
                 if (!this.hidden) {
@@ -121,7 +122,7 @@
                         ])
                         .clamp(this.clamp)
                         .base(this.logBase)
-                        .nice();
+                        .nice(niceTickCount);
                 } else if (this.measure === null || this.measure === undefined) {
                     distinctCats = getOrderedCategories(this, "y", "x");
                     // If there are any slaves process accordingly
@@ -138,7 +139,7 @@
                         .range([this.chart._yPixels() + this.chart._heightPixels(), this.chart._yPixels()])
                         .domain([this._min, this._max])
                         .clamp(this.clamp)
-                        .nice();
+                        .nice(niceTickCount);
                 }
                 // if it's visible, orient it at the left or right if it's first or second respectively
                 if (!this.hidden) {


### PR DESCRIPTION
If the forceTickCount property is set on the axis, the call to .nice(...) will take the specified tickCount into account when generating the scale function for the axis. This prevents an issue where the specified min/max value is overridden in the axis scale by the call to .nice() as the scale function is constructed. 

An example of the issue may be seen here http://jsbin.com/menejiwuxu where there is a gap between the min-value of the x-axis and the origin of the axis.